### PR TITLE
Kind request to deprecate package in favor of the official version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,1 @@
-Font Awesome 4
-==============
-
-[Font Awesome 4.2.0](http://fontawesome.io) packaged for [Meteor](https://www.meteor.com) 0.9+
-
-Packaged by [Tim Pfafman](https://github.com/pfafman/meteor-font-awesome-4)
-
-
-### Installation
-
-```
-meteor add pfafman:font-awesome-4
-```
-
-#### Why another package of this?
-
-I needed Font Awesome 4.2 on meteor 0.9 and I could not find an existing package of this that was not working.  Yeah I know my general disclaimer...
+This package is deprecated in favor of the [official Font Awesome Meteor package](https://atmospherejs.com/fortawesome/fontawesome).


### PR DESCRIPTION
Hi Tim,

Thanks for publishing this package. In the meantime an [official Meteor integration](https://atmospherejs.com/fortawesome/fontawesome) has become available, which efficiently only ships the [minimum required fonts](https://github.com/dandv/Font-Awesome/tree/meteor-integration-5.0.0/meteor).

Would you like to support the official Font Awesome package?

If so, you can hide [your package](https://atmospherejs.com/pfafman/font-awesome-4) from Atmosphere searches, while still keeping it installable by apps and dependent packages, by running the following command:

```
meteor admin set-unmigrated pfafman:font-awesome-4
```

Thanks!
Dan & the [Meteor integrations team](https://github.com/raix/Meteor-community-discussions/issues/14)
